### PR TITLE
Adding support for protoc plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 apply plugin: 'idea'
 
 group = 'com.tomcawley'
-version = '0.3'
+version = '0.3.2'
 
 configurations {
     published.extendsFrom archives, signatures

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.6-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/src/main/groovy/com/tomcawley/ProtoBufPlugin.groovy
+++ b/src/main/groovy/com/tomcawley/ProtoBufPlugin.groovy
@@ -68,7 +68,9 @@ class ProtoBufPlugin implements Plugin<Project> {
 	
 		def sourceSets = project.container(ProtoBufSourceSet)
 		def protoc = project.container(ProtocConfig)
-		def lang = project.container(LangConfig)
+		def lang = project.container(LangConfig) {
+			new LangConfig(it, project.container(ProtocConfig))
+		}
 		
 		project.configure(project) {
 			extensions.create(ProtoBufExtension.NAME, ProtoBufExtension, sourceSets, protoc, lang)

--- a/src/main/groovy/com/tomcawley/domain/LangConfig.groovy
+++ b/src/main/groovy/com/tomcawley/domain/LangConfig.groovy
@@ -30,6 +30,8 @@ class LangConfig implements Named {
 	final String name
 	String genDir
 
+	String[] plugin
+
 	public LangConfig(String name) {
 		this.name = name
 		

--- a/src/main/groovy/com/tomcawley/domain/LangConfig.groovy
+++ b/src/main/groovy/com/tomcawley/domain/LangConfig.groovy
@@ -23,19 +23,26 @@
  */
 package com.tomcawley.domain
 
-import org.gradle.api.Named;
+import org.gradle.api.Named
+import org.gradle.api.NamedDomainObjectContainer
 
 class LangConfig implements Named {
 
 	final String name
 	String genDir
 
-	String[] plugin
+	final NamedDomainObjectContainer<ProtocConfig> plugin
 
-	public LangConfig(String name) {
+	public LangConfig(String name, NamedDomainObjectContainer<ProtocConfig> plugin) {
 		this.name = name
+		this.plugin = plugin
 		
 		// Default, e.g., src/main/java, src/main/cpp, etc.
 		genDir = "src/main/$name"
+	}
+
+
+	def plugin(Closure closure) {
+		plugin.configure(closure)
 	}
 }

--- a/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
+++ b/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
@@ -60,7 +60,7 @@ class ProtoBufCompileTask extends DefaultTask {
 
 			println "Compiling $protoFile.name for $os"
 
-			def protocConfig = project.protoBuf.protoc.findByName(os)
+			def protocConfig = project.protoBuf.protoc.find { os.matches(it.name) }
 			
 			checkProtocConfig(protocConfig, os)
 			

--- a/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
+++ b/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
@@ -65,7 +65,7 @@ class ProtoBufCompileTask extends DefaultTask {
 			checkProtocConfig(protocConfig, os)
 			
 			project.protoBuf.lang.each { LangConfig lang ->
-				executeProtoc(protocConfig.path, srcDir.absolutePath, lang, protoFile.absolutePath)
+				executeProtoc(protocConfig.path, srcDir.absolutePath, lang, protoFile.absolutePath, os)
 			}
 		}
 		
@@ -90,11 +90,11 @@ class ProtoBufCompileTask extends DefaultTask {
 		return retval
 	}
 
-	def executeProtoc(String protocPath, srcDirPath, LangConfig lang, String protoFilePath) {
+	def executeProtoc(String protocPath, srcDirPath, LangConfig lang, String protoFilePath, os) {
 
-		def plugins = lang.plugin.collect { String plugin ->
-			"--plugin="+plugin
-		}
+		println lang.plugin
+		def matched = lang.plugin.findAll { it.name.matches(os) }
+		def plugins = matched.collect { "--plugin="+it.path }
 
 		def command = ["$protocPath",
 		"-I=${srcDirPath}"] +

--- a/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
+++ b/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
@@ -93,7 +93,7 @@ class ProtoBufCompileTask extends DefaultTask {
 	def executeProtoc(String protocPath, srcDirPath, LangConfig lang, String protoFilePath, os) {
 
 		println lang.plugin
-		def matched = lang.plugin.findAll { it.name.matches(os) }
+		def matched = lang.plugin.findAll { os.matches(it.name) }
 		def plugins = matched.collect { "--plugin="+it.path }
 
 		def command = ["$protocPath",

--- a/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
+++ b/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
@@ -91,10 +91,17 @@ class ProtoBufCompileTask extends DefaultTask {
 	}
 
 	def executeProtoc(String protocPath, srcDirPath, LangConfig lang, String protoFilePath) {
+
+		def plugins = lang.plugin.collect { String plugin ->
+			"--plugin="+plugin
+		}
+
 		def command = ["$protocPath",
-		"-I=${srcDirPath}",
-		"--${lang.name}_out=${lang.genDir}",
+		"-I=${srcDirPath}"] +
+		plugins +
+		["--${lang.name}_out=${lang.genDir}",
                 "${protoFilePath}"]
+
 		println command
 
 		def p = command.execute(null, project.projectDir)


### PR DESCRIPTION
Hi there,

I added support for referencing protoc plugins from the build script. A script using this feature looks like this:

``` groovy
java {
    plugin = ['plugin 1.exe', 'plugin 2.exe']
}
```

As plugins are also platform specific, it may be better to have platform specific paths in the same way as for protoc itself. But if you only use one platform, this approach works quite well.

Regards,
Jakob Wenzel
