### PR TITLE
match os name using regex

### DIFF
--- a/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
+++ b/src/main/groovy/com/tomcawley/tasks/ProtoBufCompileTask.groovy
@@ -60,7 +60,7 @@ class ProtoBufCompileTask extends DefaultTask {
 
 			println "Compiling $protoFile.name for $os"
 
-			def protocConfig = project.protoBuf.protoc.findByName(os)
+			def protocConfig = project.protoBuf.protoc.find { os.matches(it.name) }
 			
 			checkProtocConfig(protocConfig, os)
 			


### PR DESCRIPTION
Hi there,

this patch changes matching for os names to use Regexes. Now you can use things like

``` groovy
        'Windows.*' {
            path = ".../protoc.exe"
        }
```

to match all versions of Windows.

Greetings,
Jakob Wenzel
